### PR TITLE
Urls as properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,15 +37,19 @@
     <sonar.version>4.5.4</sonar.version>
     <sonar.pluginName>Stash</sonar.pluginName>
     <sonar.pluginClass>org.sonar.plugins.stash.StashPlugin</sonar.pluginClass>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
     <test.sonarqube.dist.groupId>fixme.fixme</test.sonarqube.dist.groupId>
     <test.sonarqube.dist.artifactId>sonarqube-dist</test.sonarqube.dist.artifactId>
     <test.sonarqube.dist.version>6.0</test.sonarqube.dist.version>
     <test.sonarqube.dist.outputdir>${project.build.directory}/fixtures/sonarqube</test.sonarqube.dist.outputdir>
+
     <test.sonarscanner.dist.groupId>fixme.fixme</test.sonarscanner.dist.groupId>
     <test.sonarscanner.dist.artifactId>sonarscanner-dist</test.sonarscanner.dist.artifactId>
     <test.sonarscanner.dist.version>2.6.1</test.sonarscanner.dist.version>
     <test.sonarscanner.dist.outputdir>${project.build.directory}/fixtures/sonarscanner</test.sonarscanner.dist.outputdir>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    
+    <test.url.binaries.repo>https://sonarsource.bintray.com/Distribution</test.url.binaries.repo>
     <test.plugin.archive>${project.build.directory}/${project.artifactId}-${project.version}.jar</test.plugin.archive>
     <test.sources.dir>${project.build.directory}/fixtures/sources</test.sources.dir>
   </properties>
@@ -157,7 +161,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-${test.sonarqube.dist.version}.zip</url>
+              <url>${test.url.binaries.repo}/sonarqube/sonarqube-${test.sonarqube.dist.version}.zip</url>
               <unpack>true</unpack>
               <outputDirectory>${test.sonarqube.dist.outputdir}</outputDirectory>
             </configuration>
@@ -169,7 +173,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-${test.sonarscanner.dist.version}.zip</url>
+              <url>${test.url.binaries.repo}/sonar-scanner-cli/sonar-scanner-${test.sonarscanner.dist.version}.zip</url>
               <unpack>true</unpack>
               <outputDirectory>${test.sonarscanner.dist.outputdir}</outputDirectory>
             </configuration>

--- a/src/main/java/org/sonar/plugins/stash/PluginUtils.java
+++ b/src/main/java/org/sonar/plugins/stash/PluginUtils.java
@@ -8,6 +8,11 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 public class PluginUtils {
+
+    // Hiding implicit public constructor with an explicit private one (squid:S1118)
+    private PluginUtils() {
+    }
+    
     public static PluginInfo infoForPluginClass(Class klass) {
         try {
             Enumeration<URL> resources = klass.getClassLoader().getResources("META-INF/MANIFEST.MF");

--- a/src/main/java/org/sonar/plugins/stash/issue/collector/StashCollector.java
+++ b/src/main/java/org/sonar/plugins/stash/issue/collector/StashCollector.java
@@ -260,7 +260,6 @@ public final class StashCollector {
   }
 
   public static long getNextPageStart(JSONObject jsonObject) throws StashReportExtractionException {
-    long result = 0;
 
     if (jsonObject.get("nextPageStart") != null) {
       return (Long) jsonObject.get("nextPageStart");

--- a/src/main/java/org/sonar/plugins/stash/issue/collector/StashCollector.java
+++ b/src/main/java/org/sonar/plugins/stash/issue/collector/StashCollector.java
@@ -17,6 +17,9 @@ import org.sonar.plugins.stash.issue.StashUser;
 
 public final class StashCollector {
 
+   private static final String AUTHOR  = "author";
+   private static final String VERSION = "version";
+
   private StashCollector() {
     // NOTHING TO DO
     // Pure static class
@@ -45,9 +48,12 @@ public final class StashCollector {
     long id = (long) jsonComment.get("id");
     String message = (String) jsonComment.get("text");
 
-    StashUser stashUser = extractUser((JSONObject) jsonComment.get("author"));
+    long version = (long) jsonComment.get(VERSION);
 
-    result = new StashComment(id, message, path, line, stashUser, (long) jsonComment.get("version"));
+    JSONObject jsonAuthor = (JSONObject) jsonComment.get(AUTHOR);
+    StashUser stashUser = extractUser(jsonAuthor);
+
+    result = new StashComment(id, message, path, line, stashUser, version);
 
     return result;
   }
@@ -73,7 +79,8 @@ public final class StashCollector {
   public static StashPullRequest extractPullRequest(String project, String repository, String pullRequestId, JSONObject jsonPullRequest) throws StashReportExtractionException {
     StashPullRequest result = new StashPullRequest(project, repository, pullRequestId);
 
-    result.setVersion((long) jsonPullRequest.get("version"));
+    long version = (long) jsonPullRequest.get(VERSION);
+    result.setVersion(version);
 
     JSONArray jsonReviewers = (JSONArray) jsonPullRequest.get("reviewers");
     if (jsonReviewers != null) {
@@ -156,14 +163,14 @@ public final class StashCollector {
                                 if (lineCommentId == commentId) {
 
                                   String lineCommentMessage = (String) jsonLineComment.get("text");
+                                  long lineCommentVersion = (long) jsonLineComment.get(VERSION);
 
-                                  JSONObject objAuthor = (JSONObject) jsonLineComment.get("author");
+                                  JSONObject objAuthor = (JSONObject) jsonLineComment.get(AUTHOR);
                                   if (objAuthor != null) {
 
                                     StashUser author = extractUser(objAuthor);
 
-                                    StashComment comment = new StashComment(lineCommentId, lineCommentMessage, path,
-                                                        destination, author, (long) jsonLineComment.get("version"));
+                                    StashComment comment = new StashComment(lineCommentId, lineCommentMessage, path, destination, author, lineCommentVersion);
                                     diff.addComment(comment);
 
                                     // get the tasks linked to the current comment
@@ -201,14 +208,14 @@ public final class StashCollector {
 
                 long lineCommentId = (long) jsonLineComment.get("id");
                 String lineCommentMessage = (String) jsonLineComment.get("text");
+                long lineCommentVersion = (long) jsonLineComment.get(VERSION);
 
-                JSONObject objAuthor = (JSONObject) jsonLineComment.get("author");
+                JSONObject objAuthor = (JSONObject) jsonLineComment.get(AUTHOR);
                 if (objAuthor != null) {
 
                   StashUser author = extractUser(objAuthor);
 
-                  StashComment comment = new StashComment(lineCommentId, lineCommentMessage, path, (long) 0, author,
-                                                            (long) jsonLineComment.get("version"));
+                  StashComment comment = new StashComment(lineCommentId, lineCommentMessage, path, (long) 0, author, lineCommentVersion);
                   initialDiff.addComment(comment);
                 }
               }
@@ -253,6 +260,7 @@ public final class StashCollector {
   }
 
   public static long getNextPageStart(JSONObject jsonObject) throws StashReportExtractionException {
+    long result = 0;
 
     if (jsonObject.get("nextPageStart") != null) {
       return (Long) jsonObject.get("nextPageStart");


### PR DESCRIPTION
When targetting Bintray is not possible or not the faster solution, now it is easy to overwrite the URL during the build and get an alternative (instead of patching the pom).