### PR TITLE
accept json responses with parameters

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/ContentType.java
+++ b/src/main/java/org/sonar/plugins/stash/ContentType.java
@@ -1,0 +1,30 @@
+package org.sonar.plugins.stash;
+
+import org.apache.commons.lang3.StringUtils;
+
+/*
+ * basic implementation of RFC 7231, section 3.1.1.1
+ * subset of javax.mail.internet.ContentType
+ */
+public class ContentType {
+    private String primaryType, subType;
+
+    public ContentType(String primaryType, String subType, Object list) {
+        if (list != null) {
+            throw new IllegalArgumentException();
+        }
+        this.primaryType = primaryType;
+        this.subType = subType;
+    }
+
+    public boolean match(String s) {
+        String[] parts = s.split(";", 2);
+        // we ignore the parameters, match() does not care and we can't have our own
+        String[] types = StringUtils.strip(parts[0]).split("/", 2);
+        if (types.length < 2) {
+            return  false;
+        }
+        return  StringUtils.equalsIgnoreCase(primaryType, types[0])
+             && StringUtils.equalsIgnoreCase(subType, types[1]);
+    }
+}

--- a/src/main/java/org/sonar/plugins/stash/client/StashClient.java
+++ b/src/main/java/org/sonar/plugins/stash/client/StashClient.java
@@ -12,6 +12,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.sonar.plugins.stash.ContentType;
 import org.sonar.plugins.stash.PluginInfo;
 import org.sonar.plugins.stash.PluginUtils;
 import org.sonar.plugins.stash.StashPlugin;
@@ -68,6 +69,7 @@ public class StashClient implements AutoCloseable {
   private static final String TASK_POST_ERROR_MESSAGE = "Unable to post a task on comment {0}.";
   private static final String TASK_DELETION_ERROR_MESSAGE = "Unable to delete task {0}.";
 
+  private static final ContentType JSON = new ContentType("application", "json", null);
 
   public StashClient(String url, StashCredentials credentials, int stashTimeout) {
     this.baseUrl = url;
@@ -311,7 +313,7 @@ public class StashClient implements AutoCloseable {
     }
 
     String contentType = response.getHeader("Content-Type");
-    if (!"application/json".equals(contentType)) {
+    if (!JSON.match(StringUtils.strip(contentType))) {
       throw new StashClientException("Received response with type " + contentType + " instead of JSON");
     }
     try {

--- a/src/test/java/org/sonar/plugins/stash/ContentTypeTest.java
+++ b/src/test/java/org/sonar/plugins/stash/ContentTypeTest.java
@@ -12,6 +12,10 @@ public class ContentTypeTest {
         Assert.assertTrue(json.match("APPLICATION/JSON"));
         Assert.assertTrue(json.match("ApPlIcAtIoN/jSoN"));
 
+        Assert.assertFalse(json.match(""));
+        Assert.assertFalse(json.match("/"));
+        Assert.assertFalse(json.match(";"));
+        Assert.assertFalse(json.match("/;"));
         Assert.assertFalse(json.match("foo"));
         Assert.assertFalse(json.match("12!4"));
         Assert.assertFalse(json.match("foo/json"));

--- a/src/test/java/org/sonar/plugins/stash/ContentTypeTest.java
+++ b/src/test/java/org/sonar/plugins/stash/ContentTypeTest.java
@@ -1,0 +1,21 @@
+package org.sonar.plugins.stash;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ContentTypeTest {
+    @Test
+    public void testContentType() {
+        ContentType json = new ContentType("application", "json", null);
+        Assert.assertTrue(json.match("application/json"));
+        Assert.assertTrue(json.match("application/json;charset=utf-8"));
+        Assert.assertTrue(json.match("APPLICATION/JSON"));
+        Assert.assertTrue(json.match("ApPlIcAtIoN/jSoN"));
+
+        Assert.assertFalse(json.match("foo"));
+        Assert.assertFalse(json.match("12!4"));
+        Assert.assertFalse(json.match("foo/json"));
+        Assert.assertFalse(json.match("application/foo"));
+        Assert.assertFalse(json.match("application/foo;charset=utf-8"));
+    }
+}


### PR DESCRIPTION
Some services use application/json with the charset= parameter.
This violates the spec but we handle it gracefully.

closes #71 and #72

Cc: @re-schneider @acopet 