### PR TITLE
SONARQUBE.COM: config to explicitely run analysis using the new service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
 
 script:
   - ./.travis/script.sh
-  - [ "${SQ_RUN}" == "yes" ] && ./.travis/runSonarQubeAnalysis.sh
+  - ./.travis/runSonarQubeAnalysis.sh
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,26 @@ matrix:
         - TEST_SUITE=integration
         - SONARQUBE_VERSION=4.5.7
 
+env:
+  global:
+    # GITHUB_LOGIN
+    - secure: "TtwVKb3G1ysoZeHyP36SW21aztdCzDo7FkFTuZzLVfaK08FzDrac8lIaE0wvSAx8Xupyzm17yk9XkH9DEDtSi6YVqq0yM30X21pHbHhOkRNwdHNliKjInq7OdP6BSktXoc0shDq9pSfXvYKu9El8nKQ7IaV0GJ67iMU6fnHllCvmD5EuSSj49t4NnmNANHDuLaMJplHhuCPdtcqmwByLu6bCjzRus6yos+4KV2bnSVUFSb5Qaeot7azasvU62jXz6KtsB7nH968SI32n2Wo7w1HxoBNbIB0n/abF9VYNGXA/ouZwy/zTns66JTQ3PYk2UoDTL9zLh8NUv5/Q7pVHAOPBscTHPZiEZdswgQrW52S5IC1dUIZmGtP2QcknV1zUjh04ank/BFUCvgHOK3KEYyxjTt3fJGp7WppO7yata/IjVn9H7PLHremNJ6pO53EWYftil65F6SPJJNWpylMITvnAOPVEON/WmxgHln971Hx1JAictNZjXKxG8yTTnuEeV0oBt5CL5GxYtyFvM1MYQaogrEoNApmBJ5E499WQ2rN5FqcAHI9GNHTDL0HTyYGNfHTar80XfzwfvsQ0W/KTlHcBcqJqdeSi4dYimcuocOCdPbmAm+1zPyx32dOv5IgllqIP0Z6+v7tTBVdKDgCohSaMZM7Zs7rE/Ba/kA3BN3I="
+    #
+    # GITHUB_TOKEN
+    - secure: "BL7JpZG4+pes5n8oIA3wEDqv81+Qh/+i/4O7H2C3ZzYd+eWnYLfSt4XLGzKorokV+H9WAQpgtoc163UVkfCbJ07N7xqof7tMWUwTD/OPTwhpj4/qAuz3itZG5r/AlVTL6gfXF4nd19qwotJ3FJaDla4hbHQOPdH1SHSiMWDP76dWjqxnbY44bQt9mfxM9jMwtykRjxPXHZUeFMA66w2nqIyVrQsjZNFajC5u4VY9KU0VCPyDMV9lB/wv2ncm6fnilwh90b0Yh/3qqmQnPz7l+dj+0dvveFGXQvKH0FwbK4h4KsgiiIplMmpT4Cr1H0oysOHL+NKcpAhcdc4mh0ZtzURi4JVZvrp7+XZDFJjLpj89ErsQJtfiKfS4n5/BgsA0g+UDDvwRXDkichiETY6Ubge5Toc1qHgqEB5jfLZFwVE4eGgZAxXClfVdt5GBhEaANeJ98ffb6LAlv3dkJova32/wS/0y5cwOOWXypGjCMfhbhDxu7AIVtfbF6UhrW3xngSsTUI9cxHIpjuGdDtEIktW2N0KskZN1FMEEIaHT2dqXCM1JJRTbUOgpnzuSBEJMCuKJoGLx9GSodAuD92y3WntJrEZ+HZx7UklwHBtvtmGuwToHLUotmJejxxuLORnYGguCrZ86f6nyMQfY6n0yvnvNLnkzZgX0airrOVDTW48="
+    #
+    - SONAR_HOST_URL="https://sonarqube.com"
+    #
+    # SONAR_TOKEN
+    - secure: "ux1NYGmQR9xdobfJ9fMnh0oGmAUwlQ6d5neeptyopwD5SgtPawkjEL14jH+oIMiStwWU9psPR4jE7Unttmi+j94j2gJE91uwyVGYsjcqGOHxTh8hbsLX5aeI+0NitXkSraM8iY7WT2gGgH6n8G9QQXDVPCWO0MDQUzNjTI8XM1MYgVehSNXes2mzO7JN8pX+YSjsrFSG1j6Zwz0IiZIPvC5upS/w9JwLqyHeZqlpYVy5S+Gl3oGGtwONHyEM0vNs3YMgR4ylzLzRlNl40JvjLRbLDikS44O+W3ADBFe122p2OYMzVZN+KN8RuYqpJLggKWZijsZ09Yl/4ReRDZGwVg5uylcjUaAlwRfkW1pP6yuXgBqOmwBXfSXqflYERt8YUWrGcnT534WnffpjR+dW5d735DQv6uZkSA/dWBnhI8CmK6XbyNHSfRXTtTiL2Uogd6DpDtUghErz0408a/zvtBAhrrVA03AqutGVefyiSs/uWpDVM1cvB9gUD7AXB/MtZi4hgB/lSy4/DH2Fy1kDLVPvcnQpnAlaAPu88jCXIQtbzN+Ol1qe+yUj44YW5X0FxhGUrCa/akZh6DPCUn03gK6gY1zd1+5zPl73FnbVjpwTrNZZM+l78tW8L612aqSSItsnBi/oTrjWYXGvbCImTcxmkp266qSWmoML2PEp6s8="
+
+
 install:
   - mvn dependency:go-offline
 
 script:
   - ./.travis/script.sh
+  - ./.travis/runSonarQubeAnalysis.sh
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,30 @@ language: java
 matrix:
   fast_finish: true
   include:
+    # The basic unit-tests environments
     - jdk: oraclejdk8
-      env: TEST_SUITE=unit
+      env:
+        - TEST_SUITE=unit
+        - SQ_RUN=yes
+        # It is necessary only to run the analysis once ;)
+
     - jdk: oraclejdk7
       env: TEST_SUITE=unit
+
     - jdk: openjdk7
       env: TEST_SUITE=unit
+
+    # The integration tests environments
     - jdk: oraclejdk8
       env:
         - TEST_SUITE=integration
         - SONARQUBE_VERSION=6.0
+
     - jdk: oraclejdk8
       env:
         - TEST_SUITE=integration
         - SONARQUBE_VERSION=5.6
+
     - jdk: oraclejdk8
       env:
         - TEST_SUITE=integration
@@ -41,7 +51,7 @@ install:
 
 script:
   - ./.travis/script.sh
-  - ./.travis/runSonarQubeAnalysis.sh
+  - [ "${SQ_RUN}" == "yes" ] && ./.travis/runSonarQubeAnalysis.sh
 
 sudo: false
 

--- a/.travis/runSonarQubeAnalysis.sh
+++ b/.travis/runSonarQubeAnalysis.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Exit on failure
+set -e
+
+#
+# SOURCE: https://github.com/bellingard/multi-language-project/blob/master/runSonarQubeAnalysis.sh
+#
+
+# This assumes that the 2 following variables are defined:
+# - SONAR_HOST_URL => should point to the public URL of the SQ server (e.g. for Nemo: https://nemo.sonarqube.org)
+# - SONAR_TOKEN    => token of a user who has the "Execute Analysis" permission on the SQ server
+
+# And run the analysis
+# It assumes that the project uses Maven and has a POM at the root of the repo
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+	# => This will run a full analysis of the project and push results to the SonarQube server.
+	#
+	# Analysis is done only on master so that build of branches don't push analyses to the same project and therefore "pollute" the results
+	echo "Starting analysis by SonarQube..."
+	mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -B -e -V \
+		-Dsonar.host.url=$SONAR_HOST_URL \
+		-Dsonar.login=$SONAR_TOKEN
+
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ -n "${GITHUB_TOKEN-}" ]; then
+	# => This will analyse the PR and display found issues as comments in the PR, but it won't push results to the SonarQube server
+	#
+	# For security reasons environment variables are not available on the pull requests
+	# coming from outside repositories
+	# http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests
+	# That's why the analysis does not need to be executed if the variable GITHUB_TOKEN is not defined.
+	echo "Starting Pull Request analysis by SonarQube..."
+	mvn clean package sonar:sonar -B -e -V \
+		-Dsonar.host.url=$SONAR_HOST_URL \
+		-Dsonar.login=$SONAR_TOKEN \
+		-Dsonar.analysis.mode=preview \
+		-Dsonar.github.oauth=$GITHUB_TOKEN \
+		-Dsonar.github.repository=$TRAVIS_REPO_SLUG \
+		-Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST
+
+else
+	# When neither on master branch nor on a non-external pull request => nothing to do
+	#
+	# However, it is good to know why we are here
+	echo "No SonarQube anaysis necessary in this case (current branch: ${TRAVIS_BRANCH})..."
+
+	# It is useful to know what is the status of the secure entries (can explain why it was not started)
+	if [ -n "${GITHUB_TOKEN-}" ]; then
+		echo -e "\t=> GITHUB_TOKEN is defined"
+	else
+		echo -e "\t=> GITHUB_TOKEN is  NOT defined"
+	fi
+
+	if [ -n "${SONAR_TOKEN-}" ]; then
+		echo -e "\t=> SONAR_TOKEN is defined"
+	else
+		echo -e "\t=> SONAR_TOKEN is NOT defined"
+	fi
+
+fi

--- a/.travis/runSonarQubeAnalysis.sh
+++ b/.travis/runSonarQubeAnalysis.sh
@@ -10,6 +10,13 @@ set -e
 # - SONAR_HOST_URL => should point to the public URL of the SQ server (e.g. for Nemo: https://nemo.sonarqube.org)
 # - SONAR_TOKEN    => token of a user who has the "Execute Analysis" permission on the SQ server
 
+# We don't want to run X times the same analysis because of the matrix configuration
+if [ "${SQ_RUN}" != "yes" ]; then
+	echo "Duplicated run detected, skipping the SonarQube analysis..."
+	exit 0
+fi
+
+
 # And run the analysis
 # It assumes that the project uses Maven and has a POM at the root of the repo
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then


### PR DESCRIPTION
Nemo is now dead since September 1st: https://about.sonarqube.com/news/2016/09/01/sonarqubedotcom-open-to-aynone.html

All the security information are access_token encrypted through Travis (not decipherable outside of Travis and not usable as-is outside of this repo).

MAIN LIMITATION: does not run on PR from forks... (https://docs.travis-ci.com/user/encryption-keys/)