### PR TITLE
Comment on file cannot specify line 0 in the API request

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/client/StashClient.java
+++ b/src/main/java/org/sonar/plugins/stash/client/StashClient.java
@@ -141,8 +141,10 @@ public class StashClient implements AutoCloseable {
     String request = MessageFormat.format(API_ONE_PR_ALL_COMMENTS, baseUrl, project, repository, pullRequestId);
 
     JSONObject anchor = new JSONObject();
-    anchor.put("line", line);
-    anchor.put("lineType", type);
+    if (line != 0L) {
+      anchor.put("line", line);
+      anchor.put("lineType", type);
+    }
     
     String fileType = "TO";
     if (StringUtils.equals(type, StashPlugin.CONTEXT_ISSUE_TYPE)){


### PR DESCRIPTION
This fix the issue that Stash returns 400 for file-level comments. REST API documentation says that line and lineType should not be specified for such comments:
[https://developer.atlassian.com/static/rest/bitbucket-server/4.12.1/bitbucket-rest.html#idm45699330875184]