### PR TITLE
refactor(StashClient): introducing an interface to provide an alterna…

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/StashIssueReportingPostJob.java
+++ b/src/main/java/org/sonar/plugins/stash/StashIssueReportingPostJob.java
@@ -10,6 +10,7 @@ import org.sonar.api.resources.Project;
 import org.sonar.plugins.stash.client.SonarQubeClient;
 import org.sonar.plugins.stash.client.StashClient;
 import org.sonar.plugins.stash.client.StashCredentials;
+import org.sonar.plugins.stash.client.StashServerClient;
 import org.sonar.plugins.stash.exceptions.StashConfigurationException;
 import org.sonar.plugins.stash.issue.CoverageIssuesReport;
 import org.sonar.plugins.stash.issue.SonarQubeIssuesReport;
@@ -49,10 +50,12 @@ public class StashIssueReportingPostJob implements PostJob {
           
         StashCredentials stashCredentials = stashRequestFacade.getCredentials();
 
-        try (StashClient stashClient = new StashClient(stashURL, stashCredentials, stashTimeout, config.getSonarQubeVersion())) {
+        try (StashClient stashClient = new StashServerClient(stashURL, stashCredentials, stashTimeout, config.getSonarQubeVersion())) {
 
           // Down the rabbit hole...
           updateStashWithSonarInfo(stashClient, stashCredentials, project, context);
+        } catch (Exception e) {
+          // ignored
         }
       }
     } catch (StashConfigurationException e) {

--- a/src/main/java/org/sonar/plugins/stash/client/StashClient.java
+++ b/src/main/java/org/sonar/plugins/stash/client/StashClient.java
@@ -1,370 +1,45 @@
 package org.sonar.plugins.stash.client;
 
-import org.apache.commons.lang3.StringUtils;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.BoundRequestBuilder;
-import org.asynchttpclient.DefaultAsyncHttpClient;
-import org.asynchttpclient.DefaultAsyncHttpClientConfig;
-import org.asynchttpclient.Realm;
-import org.asynchttpclient.Response;
-import org.asynchttpclient.config.AsyncHttpClientConfigDefaults;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
-import org.sonar.plugins.stash.ContentType;
-import org.sonar.plugins.stash.PluginInfo;
-import org.sonar.plugins.stash.PluginUtils;
+import java.util.ArrayList;
+
 import org.sonar.plugins.stash.PullRequestRef;
-import org.sonar.plugins.stash.StashPlugin;
 import org.sonar.plugins.stash.exceptions.StashClientException;
-import org.sonar.plugins.stash.exceptions.StashReportExtractionException;
 import org.sonar.plugins.stash.issue.StashComment;
 import org.sonar.plugins.stash.issue.StashCommentReport;
 import org.sonar.plugins.stash.issue.StashDiffReport;
 import org.sonar.plugins.stash.issue.StashPullRequest;
 import org.sonar.plugins.stash.issue.StashTask;
 import org.sonar.plugins.stash.issue.StashUser;
-import org.sonar.plugins.stash.issue.collector.StashCollector;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+public interface StashClient extends AutoCloseable {
 
-import static java.net.HttpURLConnection.HTTP_CREATED;
+  String getBaseUrl();
 
-public class StashClient implements AutoCloseable {
+  void postCommentOnPullRequest(PullRequestRef pr, String printReportMarkdown) throws StashClientException;
 
-  private final String baseUrl;
-  private final StashCredentials credentials;
-  private final int stashTimeout;
-  private AsyncHttpClient httpClient;
+  void approvePullRequest(PullRequestRef pr) throws StashClientException;
 
-  private static final String REST_API = "/rest/api/1.0/";
-  private static final String USER_API = "{0}" + REST_API + "users/{1}";
-  private static final String REPO_API = "{0}" + REST_API + "projects/{1}/repos/{2}/";
-  private static final String TASKS_API = REST_API + "tasks";
+  Object getLogin();
 
-  private static final String API_ALL_PR = REPO_API + "pull-requests/";
-  private static final String API_ONE_PR = API_ALL_PR + "{3,number,#}";
+  void resetPullRequestApproval(PullRequestRef pr) throws StashClientException;
 
-  private static final String API_ONE_PR_ALL_COMMENTS = API_ONE_PR + "/comments";
-  private static final String API_ONE_PR_DIFF = API_ONE_PR + "/diff?withComments=true";
-  private static final String API_ONE_PR_APPROVAL = API_ONE_PR + "/approve";
-  private static final String API_ONE_PR_COMMENT_PATH = API_ONE_PR + "/comments?path={4}&start={5,number,#}";
+  StashPullRequest getPullRequest(PullRequestRef pr) throws StashClientException;
 
-  private static final String API_ONE_PR_ONE_COMMENT = API_ONE_PR_ALL_COMMENTS + "/{4}?version={5}";
+  StashUser getUser(String user) throws StashClientException;
 
-  private static final String PULL_REQUEST_APPROVAL_POST_ERROR_MESSAGE = "Unable to change status of pull-request {0} #{1,number,#}.";
-  private static final String PULL_REQUEST_GET_ERROR_MESSAGE = "Unable to retrieve pull-request {0} #{1,number,#}.";
-  private static final String PULL_REQUEST_PUT_ERROR_MESSAGE = "Unable to update pull-request {0} #{1,number,#}.";
-  private static final String USER_GET_ERROR_MESSAGE = "Unable to retrieve user {0}.";
-  private static final String COMMENT_POST_ERROR_MESSAGE = "Unable to post a comment to {0} #{1,number,#}.";
-  private static final String COMMENT_GET_ERROR_MESSAGE = "Unable to get comment linked to {0} #{1,number,#}.";
-  private static final String COMMENT_DELETION_ERROR_MESSAGE = "Unable to delete comment {0,number,#} from pull-request {1} #{2,number,#}.";
-  private static final String TASK_POST_ERROR_MESSAGE = "Unable to post a task on comment {0,number,#}.";
-  private static final String TASK_DELETION_ERROR_MESSAGE = "Unable to delete task {0,number,#}.";
+  void addPullRequestReviewer(PullRequestRef pr, long version, ArrayList<StashUser> reviewers) throws StashClientException;
 
-  private static final ContentType JSON = new ContentType("application", "json", null);
+  StashCommentReport getPullRequestComments(PullRequestRef pr, String path) throws StashClientException;
 
-  public StashClient(String url, StashCredentials credentials, int stashTimeout, String sonarQubeVersion) {
-    this.baseUrl = url;
-    this.credentials = credentials;
-    this.stashTimeout = stashTimeout;
-    this.httpClient = createHttpClient(sonarQubeVersion);
-  }
+  StashComment postCommentLineOnPullRequest(PullRequestRef pr, String printIssueMarkdown,
+      String path, long line, String type) throws StashClientException;
 
-  public String getBaseUrl() {
-    return baseUrl;
-  }
+  void postTaskOnComment(String message, Long commentId) throws StashClientException;
 
-  public String getLogin() {
-    return credentials.getLogin();
-  }
+  StashDiffReport getPullRequestDiffs(PullRequestRef pr) throws StashClientException;
 
-  public void postCommentOnPullRequest(PullRequestRef pr, String report)
-      throws StashClientException {
+  void deleteTaskOnComment(StashTask task) throws StashClientException;
 
-    String request = MessageFormat.format(API_ONE_PR_ALL_COMMENTS, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
-    JSONObject json = new JSONObject();
-    json.put("text", report);
+  void deletePullRequestComment(PullRequestRef pr, StashComment comment) throws StashClientException;
 
-    postCreate(request, json, MessageFormat.format(COMMENT_POST_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
-  }
-
-  public StashCommentReport getPullRequestComments(PullRequestRef pr, String path)
-      throws StashClientException {
-    StashCommentReport result = new StashCommentReport();
-
-    long start = 0;
-    boolean isLastPage = false; 
-    
-    while (! isLastPage){
-      try {
-        String request = MessageFormat.format(API_ONE_PR_COMMENT_PATH, baseUrl, pr.project(), pr.repository(), pr.pullRequestId(), path, start);
-        JSONObject jsonComments = get(request, MessageFormat.format(COMMENT_GET_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
-        result.add(StashCollector.extractComments(jsonComments));
-
-        // Stash pagination: check if you get all comments linked to the pull-request
-        isLastPage = StashCollector.isLastPage(jsonComments);
-        start = StashCollector.getNextPageStart(jsonComments);
-      } catch (StashReportExtractionException e) {
-        throw new StashClientException(e);
-      }
-    }
-  
-    return result;
-  } 
-  
-  public void deletePullRequestComment(PullRequestRef pr, StashComment comment)
-      throws StashClientException {
-
-    String request = MessageFormat.format(API_ONE_PR_ONE_COMMENT, baseUrl, pr.project(), pr.repository(), pr.pullRequestId(),
-                                          Long.toString(comment.getId()), Long.toString(comment.getVersion()));
-
-    delete(request, MessageFormat.format(COMMENT_DELETION_ERROR_MESSAGE, comment.getId(), pr.repository(), pr.pullRequestId()));
-  }
-
-  public StashDiffReport getPullRequestDiffs(PullRequestRef pr)
-      throws StashClientException {
-    StashDiffReport result = null;
-
-    try {
-      String request = MessageFormat.format(API_ONE_PR_DIFF, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
-      JSONObject jsonDiffs = get(request, MessageFormat.format(COMMENT_GET_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
-      result = StashCollector.extractDiffs(jsonDiffs);
-    } catch (StashReportExtractionException e) {
-      throw new StashClientException(e);
-    }
-
-    return result;
-  }
-
-  public StashComment postCommentLineOnPullRequest(PullRequestRef pr, String message, String path, long line, String type)
-      throws StashClientException {
-    String request = MessageFormat.format(API_ONE_PR_ALL_COMMENTS, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
-
-    JSONObject anchor = new JSONObject();
-    anchor.put("line", line);
-    anchor.put("lineType", type);
-    
-    String fileType = "TO";
-    if (StringUtils.equals(type, StashPlugin.CONTEXT_ISSUE_TYPE)){
-      fileType = "FROM";
-    }
-    anchor.put("fileType", fileType);
-    
-    anchor.put("path", path);
-    
-    JSONObject json = new JSONObject();
-    json.put("text", message);
-    json.put("anchor", anchor);
-
-    JSONObject response = postCreate(request, json,
-    		                         MessageFormat.format(COMMENT_POST_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
-    
-    return StashCollector.extractComment(response, path, line);
-  }
-
-  public StashUser getUser(String userSlug) throws StashClientException {
-
-    String request = MessageFormat.format(USER_API, baseUrl, userSlug);
-    JSONObject response = get(request, MessageFormat.format(USER_GET_ERROR_MESSAGE, userSlug));
-
-    return StashCollector.extractUser(response);
-  }
-  
-  public StashPullRequest getPullRequest(PullRequestRef pr)
-      throws StashClientException {
-    String request = MessageFormat.format(API_ONE_PR, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
-    JSONObject response = get(request, MessageFormat.format(PULL_REQUEST_GET_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
-
-    return StashCollector.extractPullRequest(pr, response);
-  }
-  
-  public void addPullRequestReviewer(PullRequestRef pr, long pullRequestVersion, ArrayList<StashUser> reviewers)
-      throws StashClientException {
-    String request = MessageFormat.format(API_ONE_PR, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
-
-    JSONObject json = new JSONObject();
-
-    JSONArray jsonReviewers = new JSONArray();
-    for (StashUser reviewer: reviewers) {
-      JSONObject reviewerName = new JSONObject();
-      reviewerName.put("name", reviewer.getName());
-
-      JSONObject user = new JSONObject();
-      user.put("user", reviewerName);
-
-      jsonReviewers.add(user);
-    }
-    
-    json.put("reviewers", jsonReviewers);
-    json.put("id", pr.pullRequestId());
-    json.put("version", pullRequestVersion);
-
-    put(request, json, MessageFormat.format(PULL_REQUEST_PUT_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
-  }
-
-  public void approvePullRequest(PullRequestRef pr) throws StashClientException {
-    String request = MessageFormat.format(API_ONE_PR_APPROVAL, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
-    post(request, null, MessageFormat.format(PULL_REQUEST_APPROVAL_POST_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
-  }
-  
-  public void resetPullRequestApproval(PullRequestRef pr) throws StashClientException {
-    String request = MessageFormat.format(API_ONE_PR_APPROVAL, baseUrl, pr);
-    delete(request, HttpURLConnection.HTTP_OK, MessageFormat.format(PULL_REQUEST_APPROVAL_POST_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
-  }
-  
-  public void postTaskOnComment(String message, Long commentId) throws StashClientException {
-    String request = baseUrl + TASKS_API;
-  
-    JSONObject anchor = new JSONObject();
-    anchor.put("id", commentId);
-    anchor.put("type", "COMMENT");
-
-    JSONObject json = new JSONObject();
-    json.put("anchor", anchor);
-    json.put("text", message);
-
-    postCreate(request, json, MessageFormat.format(TASK_POST_ERROR_MESSAGE, commentId));
-  }
-
-  public void deleteTaskOnComment(StashTask task) throws StashClientException {
-    String request = baseUrl + TASKS_API + "/" + task.getId();
-    delete(request, MessageFormat.format(TASK_DELETION_ERROR_MESSAGE, task.getId()));
-  }
-
-  @Override
-  public void close() {
-    try {
-      httpClient.close();
-    } catch (IOException ignored) { }
-  }
-
-  private JSONObject get(String url, String errorMessage) throws StashClientException {
-      return performRequest(httpClient.prepareGet(url), null, HttpURLConnection.HTTP_OK, errorMessage);
-  }
-
-  private JSONObject post(String url, JSONObject body, String errorMessage) throws StashClientException {
-    return performRequest(httpClient.preparePost(url), body, HttpURLConnection.HTTP_OK, errorMessage);
-  }
-
-  private JSONObject postCreate(String url, JSONObject body, String errorMessage) throws StashClientException {
-    return performRequest(httpClient.preparePost(url), body, HTTP_CREATED, errorMessage);
-  }
-
-  private JSONObject delete(String url, int expectedStatusCode, String errorMessage) throws StashClientException {
-    return performRequest(httpClient.prepareDelete(url), null, expectedStatusCode, errorMessage);
-  }
-
-  private JSONObject delete(String url, String errorMessage) throws StashClientException {
-      return delete(url, HttpURLConnection.HTTP_NO_CONTENT, errorMessage);
-  }
-
-  private JSONObject put(String url, JSONObject body, String errorMessage) throws StashClientException {
-    return performRequest(httpClient.preparePut(url), body, HttpURLConnection.HTTP_OK, errorMessage);
-  }
-
-  private JSONObject performRequest(BoundRequestBuilder requestBuilder, JSONObject body, int expectedStatusCode, String errorMessage)
-          throws StashClientException {
-    if (body != null) {
-      requestBuilder.setBody(body.toString());
-    }
-    Realm realm = new Realm.Builder(credentials.getLogin(), credentials.getPassword())
-            .setUsePreemptiveAuth(true).setScheme(Realm.AuthScheme.BASIC).build();
-    requestBuilder.setRealm(realm);
-    requestBuilder.setFollowRedirect(true);
-    requestBuilder.addHeader("Content-Type", "application/json");
-
-    try {
-      Response response = requestBuilder.execute().get(stashTimeout, TimeUnit.MILLISECONDS);
-
-      validateResponse(response, expectedStatusCode, errorMessage);
-      return extractResponse(response);
-    } catch (ExecutionException | TimeoutException | InterruptedException e) {
-      throw new StashClientException(e);
-    }
-  }
-
-  private static void validateResponse(Response response, int expectedStatusCode, String message) throws StashClientException {
-    int responseCode = response.getStatusCode();
-    if (responseCode != expectedStatusCode) {
-      throw new StashClientException(message + " Received " + responseCode + ": " + formatStashApiError(response));
-    }
-  }
-
-  private static JSONObject extractResponse(Response response) throws StashClientException {
-    String body = null;
-    body = response.getResponseBody();
-
-    if (StringUtils.isEmpty(body)) {
-      return null;
-    }
-
-    String contentType = response.getHeader("Content-Type");
-    if (!JSON.match(StringUtils.strip(contentType))) {
-      throw new StashClientException("Received response with type " + contentType + " instead of JSON");
-    }
-    try {
-      Object obj = new JSONParser().parse(body);
-      return (JSONObject)obj;
-    } catch (ParseException | ClassCastException e) {
-      throw new StashClientException("Could not parse JSON response " + e + "('" + body + "')", e);
-    }
-  }
-
-  private static String formatStashApiError(Response response) throws StashClientException {
-    JSONArray errors;
-    JSONObject responseJson = extractResponse(response);
-
-    errors = (JSONArray)responseJson.get("errors");
-
-    if (errors == null) {
-      throw new StashClientException("Error response did not contain an errors object '" + responseJson + "'");
-    }
-
-    List<String> errorParts = new ArrayList<>();
-
-    for (Object o : errors) {
-      try {
-        JSONObject error = (JSONObject)o;
-        errorParts.add((String)error.get("exceptionName") + ": " + (String)error.get("message"));
-      } catch (ClassCastException e) {
-        throw new StashClientException("Error response contained invalid error", e);
-      }
-
-    }
-
-    return StringUtils.join(errorParts, ", ");
-  }
-
-  // We can't test this, as the manifest can only be loaded when deployed from a JAR-archive.
-  // During unit testing this is not the case
-  private static String getUserAgent(String sonarQubeVersion) {
-    PluginInfo info = PluginUtils.infoForPluginClass(StashPlugin.class);
-    String name;
-    String version;
-    name = version = "unknown";
-    if (info != null) {
-      name = info.getName();
-      version = info.getVersion();
-    }
-    return MessageFormat.format("SonarQube/{0} {1}/{2} {3}",
-    sonarQubeVersion == null ? "unknown" : sonarQubeVersion,
-    name,
-    version,
-    AsyncHttpClientConfigDefaults.defaultUserAgent());
-  }
-  
-  AsyncHttpClient createHttpClient(String sonarQubeVersion){
-    return new DefaultAsyncHttpClient(
-            new DefaultAsyncHttpClientConfig.Builder().setUserAgent(getUserAgent(sonarQubeVersion)).build()
-    );
-  }
 }

--- a/src/main/java/org/sonar/plugins/stash/client/StashServerClient.java
+++ b/src/main/java/org/sonar/plugins/stash/client/StashServerClient.java
@@ -1,0 +1,382 @@
+package org.sonar.plugins.stash.client;
+
+import org.apache.commons.lang3.StringUtils;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.DefaultAsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig;
+import org.asynchttpclient.Realm;
+import org.asynchttpclient.Response;
+import org.asynchttpclient.config.AsyncHttpClientConfigDefaults;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.sonar.plugins.stash.ContentType;
+import org.sonar.plugins.stash.PluginInfo;
+import org.sonar.plugins.stash.PluginUtils;
+import org.sonar.plugins.stash.PullRequestRef;
+import org.sonar.plugins.stash.StashPlugin;
+import org.sonar.plugins.stash.exceptions.StashClientException;
+import org.sonar.plugins.stash.exceptions.StashReportExtractionException;
+import org.sonar.plugins.stash.issue.StashComment;
+import org.sonar.plugins.stash.issue.StashCommentReport;
+import org.sonar.plugins.stash.issue.StashDiffReport;
+import org.sonar.plugins.stash.issue.StashPullRequest;
+import org.sonar.plugins.stash.issue.StashTask;
+import org.sonar.plugins.stash.issue.StashUser;
+import org.sonar.plugins.stash.issue.collector.StashCollector;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static java.net.HttpURLConnection.HTTP_CREATED;
+
+public class StashServerClient implements StashClient {
+
+  private final String baseUrl;
+  private final StashCredentials credentials;
+  private final int stashTimeout;
+  private AsyncHttpClient httpClient;
+
+  private static final String REST_API = "/rest/api/1.0/";
+  private static final String USER_API = "{0}" + REST_API + "users/{1}";
+  private static final String REPO_API = "{0}" + REST_API + "projects/{1}/repos/{2}/";
+  private static final String TASKS_API = REST_API + "tasks";
+
+  private static final String API_ALL_PR = REPO_API + "pull-requests/";
+  private static final String API_ONE_PR = API_ALL_PR + "{3,number,#}";
+
+  private static final String API_ONE_PR_ALL_COMMENTS = API_ONE_PR + "/comments";
+  private static final String API_ONE_PR_DIFF = API_ONE_PR + "/diff?withComments=true";
+  private static final String API_ONE_PR_APPROVAL = API_ONE_PR + "/approve";
+  private static final String API_ONE_PR_COMMENT_PATH = API_ONE_PR + "/comments?path={4}&start={5,number,#}";
+
+  private static final String API_ONE_PR_ONE_COMMENT = API_ONE_PR_ALL_COMMENTS + "/{4}?version={5}";
+
+  private static final String PULL_REQUEST_APPROVAL_POST_ERROR_MESSAGE = "Unable to change status of pull-request {0} #{1,number,#}.";
+  private static final String PULL_REQUEST_GET_ERROR_MESSAGE = "Unable to retrieve pull-request {0} #{1,number,#}.";
+  private static final String PULL_REQUEST_PUT_ERROR_MESSAGE = "Unable to update pull-request {0} #{1,number,#}.";
+  private static final String USER_GET_ERROR_MESSAGE = "Unable to retrieve user {0}.";
+  private static final String COMMENT_POST_ERROR_MESSAGE = "Unable to post a comment to {0} #{1,number,#}.";
+  private static final String COMMENT_GET_ERROR_MESSAGE = "Unable to get comment linked to {0} #{1,number,#}.";
+  private static final String COMMENT_DELETION_ERROR_MESSAGE = "Unable to delete comment {0,number,#} from pull-request {1} #{2,number,#}.";
+  private static final String TASK_POST_ERROR_MESSAGE = "Unable to post a task on comment {0,number,#}.";
+  private static final String TASK_DELETION_ERROR_MESSAGE = "Unable to delete task {0,number,#}.";
+
+  private static final ContentType JSON = new ContentType("application", "json", null);
+
+  public StashServerClient(String url, StashCredentials credentials, int stashTimeout, String sonarQubeVersion) {
+    this.baseUrl = url;
+    this.credentials = credentials;
+    this.stashTimeout = stashTimeout;
+    this.httpClient = createHttpClient(sonarQubeVersion);
+  }
+
+  @Override
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  @Override
+  public String getLogin() {
+    return credentials.getLogin();
+  }
+
+  @Override
+  public void postCommentOnPullRequest(PullRequestRef pr, String report)
+      throws StashClientException {
+
+    String request = MessageFormat.format(API_ONE_PR_ALL_COMMENTS, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
+    JSONObject json = new JSONObject();
+    json.put("text", report);
+
+    postCreate(request, json, MessageFormat.format(COMMENT_POST_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
+  }
+
+  @Override
+  public StashCommentReport getPullRequestComments(PullRequestRef pr, String path)
+      throws StashClientException {
+    StashCommentReport result = new StashCommentReport();
+
+    long start = 0;
+    boolean isLastPage = false; 
+    
+    while (! isLastPage){
+      try {
+        String request = MessageFormat.format(API_ONE_PR_COMMENT_PATH, baseUrl, pr.project(), pr.repository(), pr.pullRequestId(), path, start);
+        JSONObject jsonComments = get(request, MessageFormat.format(COMMENT_GET_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
+        result.add(StashCollector.extractComments(jsonComments));
+
+        // Stash pagination: check if you get all comments linked to the pull-request
+        isLastPage = StashCollector.isLastPage(jsonComments);
+        start = StashCollector.getNextPageStart(jsonComments);
+      } catch (StashReportExtractionException e) {
+        throw new StashClientException(e);
+      }
+    }
+  
+    return result;
+  } 
+  
+  @Override
+  public void deletePullRequestComment(PullRequestRef pr, StashComment comment)
+      throws StashClientException {
+
+    String request = MessageFormat.format(API_ONE_PR_ONE_COMMENT, baseUrl, pr.project(), pr.repository(), pr.pullRequestId(),
+                                          Long.toString(comment.getId()), Long.toString(comment.getVersion()));
+
+    delete(request, MessageFormat.format(COMMENT_DELETION_ERROR_MESSAGE, comment.getId(), pr.repository(), pr.pullRequestId()));
+  }
+
+  @Override
+  public StashDiffReport getPullRequestDiffs(PullRequestRef pr)
+      throws StashClientException {
+    StashDiffReport result = null;
+
+    try {
+      String request = MessageFormat.format(API_ONE_PR_DIFF, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
+      JSONObject jsonDiffs = get(request, MessageFormat.format(COMMENT_GET_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
+      result = StashCollector.extractDiffs(jsonDiffs);
+    } catch (StashReportExtractionException e) {
+      throw new StashClientException(e);
+    }
+
+    return result;
+  }
+
+  @Override
+  public StashComment postCommentLineOnPullRequest(PullRequestRef pr, String message, String path, long line, String type)
+      throws StashClientException {
+    String request = MessageFormat.format(API_ONE_PR_ALL_COMMENTS, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
+
+    JSONObject anchor = new JSONObject();
+    anchor.put("line", line);
+    anchor.put("lineType", type);
+    
+    String fileType = "TO";
+    if (StringUtils.equals(type, StashPlugin.CONTEXT_ISSUE_TYPE)){
+      fileType = "FROM";
+    }
+    anchor.put("fileType", fileType);
+    
+    anchor.put("path", path);
+    
+    JSONObject json = new JSONObject();
+    json.put("text", message);
+    json.put("anchor", anchor);
+
+    JSONObject response = postCreate(request, json,
+    		                         MessageFormat.format(COMMENT_POST_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
+    
+    return StashCollector.extractComment(response, path, line);
+  }
+
+  @Override
+  public StashUser getUser(String userSlug) throws StashClientException {
+
+    String request = MessageFormat.format(USER_API, baseUrl, userSlug);
+    JSONObject response = get(request, MessageFormat.format(USER_GET_ERROR_MESSAGE, userSlug));
+
+    return StashCollector.extractUser(response);
+  }
+  
+  @Override
+  public StashPullRequest getPullRequest(PullRequestRef pr)
+      throws StashClientException {
+    String request = MessageFormat.format(API_ONE_PR, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
+    JSONObject response = get(request, MessageFormat.format(PULL_REQUEST_GET_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
+
+    return StashCollector.extractPullRequest(pr, response);
+  }
+  
+  @Override
+  public void addPullRequestReviewer(PullRequestRef pr, long pullRequestVersion, ArrayList<StashUser> reviewers)
+      throws StashClientException {
+    String request = MessageFormat.format(API_ONE_PR, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
+
+    JSONObject json = new JSONObject();
+
+    JSONArray jsonReviewers = new JSONArray();
+    for (StashUser reviewer: reviewers) {
+      JSONObject reviewerName = new JSONObject();
+      reviewerName.put("name", reviewer.getName());
+
+      JSONObject user = new JSONObject();
+      user.put("user", reviewerName);
+
+      jsonReviewers.add(user);
+    }
+    
+    json.put("reviewers", jsonReviewers);
+    json.put("id", pr.pullRequestId());
+    json.put("version", pullRequestVersion);
+
+    put(request, json, MessageFormat.format(PULL_REQUEST_PUT_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
+  }
+
+  @Override
+  public void approvePullRequest(PullRequestRef pr) throws StashClientException {
+    String request = MessageFormat.format(API_ONE_PR_APPROVAL, baseUrl, pr.project(), pr.repository(), pr.pullRequestId());
+    post(request, null, MessageFormat.format(PULL_REQUEST_APPROVAL_POST_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
+  }
+  
+  @Override
+  public void resetPullRequestApproval(PullRequestRef pr) throws StashClientException {
+    String request = MessageFormat.format(API_ONE_PR_APPROVAL, baseUrl, pr);
+    delete(request, HttpURLConnection.HTTP_OK, MessageFormat.format(PULL_REQUEST_APPROVAL_POST_ERROR_MESSAGE, pr.repository(), pr.pullRequestId()));
+  }
+  
+  @Override
+  public void postTaskOnComment(String message, Long commentId) throws StashClientException {
+    String request = baseUrl + TASKS_API;
+  
+    JSONObject anchor = new JSONObject();
+    anchor.put("id", commentId);
+    anchor.put("type", "COMMENT");
+
+    JSONObject json = new JSONObject();
+    json.put("anchor", anchor);
+    json.put("text", message);
+
+    postCreate(request, json, MessageFormat.format(TASK_POST_ERROR_MESSAGE, commentId));
+  }
+
+  @Override
+  public void deleteTaskOnComment(StashTask task) throws StashClientException {
+    String request = baseUrl + TASKS_API + "/" + task.getId();
+    delete(request, MessageFormat.format(TASK_DELETION_ERROR_MESSAGE, task.getId()));
+  }
+
+  @Override
+  public void close() throws IOException {
+      httpClient.close();
+  }
+
+  private JSONObject get(String url, String errorMessage) throws StashClientException {
+      return performRequest(httpClient.prepareGet(url), null, HttpURLConnection.HTTP_OK, errorMessage);
+  }
+
+  private JSONObject post(String url, JSONObject body, String errorMessage) throws StashClientException {
+    return performRequest(httpClient.preparePost(url), body, HttpURLConnection.HTTP_OK, errorMessage);
+  }
+
+  private JSONObject postCreate(String url, JSONObject body, String errorMessage) throws StashClientException {
+    return performRequest(httpClient.preparePost(url), body, HTTP_CREATED, errorMessage);
+  }
+
+  private JSONObject delete(String url, int expectedStatusCode, String errorMessage) throws StashClientException {
+    return performRequest(httpClient.prepareDelete(url), null, expectedStatusCode, errorMessage);
+  }
+
+  private JSONObject delete(String url, String errorMessage) throws StashClientException {
+      return delete(url, HttpURLConnection.HTTP_NO_CONTENT, errorMessage);
+  }
+
+  private JSONObject put(String url, JSONObject body, String errorMessage) throws StashClientException {
+    return performRequest(httpClient.preparePut(url), body, HttpURLConnection.HTTP_OK, errorMessage);
+  }
+
+  private JSONObject performRequest(BoundRequestBuilder requestBuilder, JSONObject body, int expectedStatusCode, String errorMessage)
+          throws StashClientException {
+    if (body != null) {
+      requestBuilder.setBody(body.toString());
+    }
+    Realm realm = new Realm.Builder(credentials.getLogin(), credentials.getPassword())
+            .setUsePreemptiveAuth(true).setScheme(Realm.AuthScheme.BASIC).build();
+    requestBuilder.setRealm(realm);
+    requestBuilder.setFollowRedirect(true);
+    requestBuilder.addHeader("Content-Type", "application/json");
+
+    try {
+      Response response = requestBuilder.execute().get(stashTimeout, TimeUnit.MILLISECONDS);
+
+      validateResponse(response, expectedStatusCode, errorMessage);
+      return extractResponse(response);
+    } catch (ExecutionException | TimeoutException | InterruptedException e) {
+      throw new StashClientException(e);
+    }
+  }
+
+  private static void validateResponse(Response response, int expectedStatusCode, String message) throws StashClientException {
+    int responseCode = response.getStatusCode();
+    if (responseCode != expectedStatusCode) {
+      throw new StashClientException(message + " Received " + responseCode + ": " + formatStashApiError(response));
+    }
+  }
+
+  private static JSONObject extractResponse(Response response) throws StashClientException {
+    String body = null;
+    body = response.getResponseBody();
+
+    if (StringUtils.isEmpty(body)) {
+      return null;
+    }
+
+    String contentType = response.getHeader("Content-Type");
+    if (!JSON.match(StringUtils.strip(contentType))) {
+      throw new StashClientException("Received response with type " + contentType + " instead of JSON");
+    }
+    try {
+      Object obj = new JSONParser().parse(body);
+      return (JSONObject)obj;
+    } catch (ParseException | ClassCastException e) {
+      throw new StashClientException("Could not parse JSON response " + e + "('" + body + "')", e);
+    }
+  }
+
+  private static String formatStashApiError(Response response) throws StashClientException {
+    JSONArray errors;
+    JSONObject responseJson = extractResponse(response);
+
+    errors = (JSONArray)responseJson.get("errors");
+
+    if (errors == null) {
+      throw new StashClientException("Error response did not contain an errors object '" + responseJson + "'");
+    }
+
+    List<String> errorParts = new ArrayList<>();
+
+    for (Object o : errors) {
+      try {
+        JSONObject error = (JSONObject)o;
+        errorParts.add((String)error.get("exceptionName") + ": " + (String)error.get("message"));
+      } catch (ClassCastException e) {
+        throw new StashClientException("Error response contained invalid error", e);
+      }
+
+    }
+
+    return StringUtils.join(errorParts, ", ");
+  }
+
+  // We can't test this, as the manifest can only be loaded when deployed from a JAR-archive.
+  // During unit testing this is not the case
+  private static String getUserAgent(String sonarQubeVersion) {
+    PluginInfo info = PluginUtils.infoForPluginClass(StashPlugin.class);
+    String name;
+    String version;
+    name = version = "unknown";
+    if (info != null) {
+      name = info.getName();
+      version = info.getVersion();
+    }
+    return MessageFormat.format("SonarQube/{0} {1}/{2} {3}",
+    sonarQubeVersion == null ? "unknown" : sonarQubeVersion,
+    name,
+    version,
+    AsyncHttpClientConfigDefaults.defaultUserAgent());
+  }
+  
+  AsyncHttpClient createHttpClient(String sonarQubeVersion){
+    return new DefaultAsyncHttpClient(
+            new DefaultAsyncHttpClientConfig.Builder().setUserAgent(getUserAgent(sonarQubeVersion)).build()
+    );
+  }
+}

--- a/src/test/java/org/sonar/plugins/stash/CompleteITCase.java
+++ b/src/test/java/org/sonar/plugins/stash/CompleteITCase.java
@@ -8,7 +8,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.sonar.plugins.stash.client.StashClient;
 import org.sonar.plugins.stash.client.StashCredentials;
 import org.sonar.plugins.stash.fixtures.MavenSonarFixtures;
 import org.sonar.plugins.stash.fixtures.SonarQubeRule;
@@ -20,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import static org.sonar.plugins.stash.client.StashClientTest.aJsonResponse;
+import static org.sonar.plugins.stash.client.StashServerClientTest.aJsonResponse;
 
 public class CompleteITCase {
     protected static SonarScanner sonarScanner;

--- a/src/test/java/org/sonar/plugins/stash/client/StashClientTest.java
+++ b/src/test/java/org/sonar/plugins/stash/client/StashClientTest.java
@@ -64,7 +64,7 @@ public class StashClientTest extends StashTest {
   @Before
   public void setUp() throws Exception {
     primeWireMock();
-    client = new StashClient("http://127.0.0.1:" + wireMock.port(),
+    client = new StashServerClient("http://127.0.0.1:" + wireMock.port(),
             new StashCredentials("login", "password"),
             timeout,
             "dummyVersion");

--- a/src/test/java/org/sonar/plugins/stash/client/StashServerClientTest.java
+++ b/src/test/java/org/sonar/plugins/stash/client/StashServerClientTest.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class StashClientTest extends StashTest {
+public class StashServerClientTest extends StashTest {
   private static final int timeout = 200;
   private static final int errorTimeout = timeout + 10;
 


### PR DESCRIPTION
This is an initial commit to convert StashClient into an interface an move the existing StashClient code into a new class by the name of StashServerClient.

The only significant change in StashServerClient was in line 258 for close() to throw an IOException and to handle this in StashIssueReportingPostJob.java line 54 since StashClient is now an interface and the try with resources has to handle this exception.