### PR TITLE
Support multi-module multi-module projects with same level parent setup

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/StashProjectBuilder.java
+++ b/src/main/java/org/sonar/plugins/stash/StashProjectBuilder.java
@@ -14,8 +14,8 @@ public class StashProjectBuilder extends ProjectBuilder {
   
   @Override
   public void build(Context context) {
-    File projectBaseDir = context.projectReactor().getRoot().getBaseDir();
-    stashRequestFacade.initialize(projectBaseDir);
+    File workingDir = new File(System.getProperty("user.dir"));
+    stashRequestFacade.initialize(workingDir);
   }
 
 }

--- a/src/main/java/org/sonar/plugins/stash/StashRequestFacade.java
+++ b/src/main/java/org/sonar/plugins/stash/StashRequestFacade.java
@@ -43,18 +43,18 @@ public class StashRequestFacade implements BatchComponent {
   private static final String STACK_TRACE = "Exception stack trace";
 
   private StashPluginConfiguration config;
-  private File projectBaseDir;
+  private File workingDir;
 
   public StashRequestFacade(StashPluginConfiguration stashPluginConfiguration) {
     this.config = stashPluginConfiguration;
   }
 
-  public void initialize(File projectBaseDir) {
-    this.projectBaseDir = projectBaseDir;
+  public void initialize(File workingDir) {
+    this.workingDir = workingDir;
   }
 
   public SonarQubeIssuesReport extractIssueReport(ProjectIssues projectIssues, InputFileCache inputFileCache) {
-    return SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, projectBaseDir);
+    return SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, workingDir);
   }
 
   /**

--- a/src/main/java/org/sonar/plugins/stash/issue/collector/SonarQubeCollector.java
+++ b/src/main/java/org/sonar/plugins/stash/issue/collector/SonarQubeCollector.java
@@ -40,7 +40,7 @@ public final class SonarQubeCollector {
    * Create issue report according to issue list generated during SonarQube
    * analysis.
    */
-  public static SonarQubeIssuesReport extractIssueReport(ProjectIssues projectIssues, InputFileCache inputFileCache, File projectBaseDir) {
+  public static SonarQubeIssuesReport extractIssueReport(ProjectIssues projectIssues, InputFileCache inputFileCache, File workingDir) {
     SonarQubeIssuesReport result = new SonarQubeIssuesReport();
 
     for (Issue issue : projectIssues.issues()) {
@@ -61,7 +61,7 @@ public final class SonarQubeCollector {
         if (inputFile == null){
           LOGGER.debug("Issue {} is not linked to a file, not added to the report", issue.key());
         } else {
-          String path = new PathResolver().relativePath(projectBaseDir, inputFile.file());
+          String path = new PathResolver().relativePath(workingDir, inputFile.file());
              
           // Create the issue and Add to report
           SonarQubeIssue stashIssue = new SonarQubeIssue(key, severity, message, rule, path, line);

--- a/src/test/java/org/sonar/plugins/stash/fixtures/SonarScanner.java
+++ b/src/test/java/org/sonar/plugins/stash/fixtures/SonarScanner.java
@@ -1,12 +1,12 @@
 package org.sonar.plugins.stash.fixtures;
 
-import com.google.common.base.Joiner;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
+
+import com.google.common.base.Joiner;
 
 public class SonarScanner {
     protected Path installDir;
@@ -32,7 +32,6 @@ public class SonarScanner {
                 .directory(installDir.toFile())
                 .inheritIO();
         List<String> command = pb.command();
-        addCliProperty(command, "sonar.projectBaseDir", baseDir);
         addCliProperty(command, "sonar.host.url", sonarqube.getUrl());
         addCliProperty(command, "sonar.sources", Joiner.on(',').join(sources));
         addCliProperty(command, "sonar.projectKey", projectKey);

--- a/src/test/java/org/sonar/plugins/stash/issue/collector/SonarQubeCollectorTest.java
+++ b/src/test/java/org/sonar/plugins/stash/issue/collector/SonarQubeCollectorTest.java
@@ -40,7 +40,7 @@ import org.sonar.plugins.stash.issue.SonarQubeIssuesReport;
 
 public class SonarQubeCollectorTest {
   
-  File projectBaseDir;
+  File workingDir;
   
   @Mock
   InputFileCache inputFileCache = mock(InputFileCache.class);
@@ -95,7 +95,7 @@ public class SonarQubeCollectorTest {
     
     context = mock(SensorContext.class);
     
-    projectBaseDir = new File("baseDir");
+    workingDir = new File("baseDir");
     
     inputFile1 = mock(InputFile.class); 
     when(inputFile1.file()).thenReturn(new File("baseDir/project/path1"));
@@ -187,7 +187,7 @@ public class SonarQubeCollectorTest {
     ArrayList<Issue> issues = new ArrayList<Issue>();
     when(projectIssues.issues()).thenReturn(issues);
     
-    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, projectBaseDir);
+    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, workingDir);
     assertTrue(report.countIssues() == 0);
   }
   
@@ -198,7 +198,7 @@ public class SonarQubeCollectorTest {
     issues.add(issue2);
     when(projectIssues.issues()).thenReturn(issues);
     
-    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, projectBaseDir);
+    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, workingDir);
     assertTrue(report.countIssues() == 2);
     assertTrue(report.countIssues("severity1") == 1);
     assertTrue(report.countIssues("severity2") == 1);
@@ -223,7 +223,7 @@ public class SonarQubeCollectorTest {
     issues.add(issue1);
     when(projectIssues.issues()).thenReturn(issues);
     
-    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, projectBaseDir);
+    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, workingDir);
     assertTrue(report.countIssues() == 1);
     assertTrue(report.countIssues("severity1") == 1);
     assertTrue(report.countIssues("severity2") == 0);
@@ -245,7 +245,7 @@ public class SonarQubeCollectorTest {
     issues.add(issue2);
     when(projectIssues.issues()).thenReturn(issues);
     
-    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, projectBaseDir);
+    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, workingDir);
     assertTrue(report.countIssues() == 1);
     assertTrue(report.countIssues("severity1") == 0);
     assertTrue(report.countIssues("severity2") == 1);
@@ -260,7 +260,7 @@ public class SonarQubeCollectorTest {
     issues.add(issue2);
     when(projectIssues.issues()).thenReturn(issues);
     
-    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, projectBaseDir);
+    SonarQubeIssuesReport report = SonarQubeCollector.extractIssueReport(projectIssues, inputFileCache, workingDir);
     assertTrue(report.countIssues() == 1);
     assertTrue(report.countIssues("severity1") == 0);
     assertTrue(report.countIssues("severity2") == 1);


### PR DESCRIPTION
Use workingDir instead of projectBaseDir to support multi-module projects with same level parent setup