### PR TITLE
added a sonar.stash.user.slug property

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/StashIssueReportingPostJob.java
+++ b/src/main/java/org/sonar/plugins/stash/StashIssueReportingPostJob.java
@@ -70,8 +70,7 @@ public class StashIssueReportingPostJob implements PostJob, BatchComponent {
       // SonarQube objects
       List<Issue> issueReport = stashRequestFacade.extractIssueReport(projectIssues);
 
-
-      StashUser stashUser = stashRequestFacade.getSonarQubeReviewer(stashCredentials.getLogin(), stashClient);
+      StashUser stashUser = stashRequestFacade.getSonarQubeReviewer(stashCredentials.getUserSlug(), stashClient);
 
       if (stashUser == null) {
         throw new StashMissingElementException("No SonarQube reviewer identified to publish to Stash the SQ analysis");
@@ -90,7 +89,7 @@ public class StashIssueReportingPostJob implements PostJob, BatchComponent {
 
       boolean canApprovePullrequest = config.canApprovePullRequest();
       if (canApprovePullrequest) {
-        stashRequestFacade.addPullRequestReviewer(pr, stashCredentials.getLogin(), stashClient);
+        stashRequestFacade.addPullRequestReviewer(pr, stashCredentials.getUserSlug(), stashClient);
       }
 
       postInfoAndPRsActions(pr, issueReport, issueThreshold, diffReport, stashClient);

--- a/src/main/java/org/sonar/plugins/stash/StashPlugin.java
+++ b/src/main/java/org/sonar/plugins/stash/StashPlugin.java
@@ -46,6 +46,7 @@ public class StashPlugin extends SonarPlugin {
   public static final String STASH_RESET_COMMENTS = "sonar.stash.comments.reset";
   public static final String STASH_URL = "sonar.stash.url";
   public static final String STASH_LOGIN = "sonar.stash.login";
+  public static final String STASH_USER_SLUG = "sonar.stash.user.slug";
   public static final String STASH_PASSWORD = "sonar.stash.password";
   public static final String STASH_PASSWORD_ENVIRONMENT_VARIABLE = "sonar.stash.password.variable";
   public static final String STASH_REVIEWER_APPROVAL = "sonar.stash.reviewer.approval";

--- a/src/main/java/org/sonar/plugins/stash/StashPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/stash/StashPluginConfiguration.java
@@ -42,6 +42,10 @@ public class StashPluginConfiguration implements BatchComponent {
     return settings.getString(StashPlugin.STASH_LOGIN);
   }
 
+  public String getStashUserSlug() {
+    return settings.getString(StashPlugin.STASH_USER_SLUG);
+  }
+
   public String getStashPassword() {
     return settings.getString(StashPlugin.STASH_PASSWORD);
   }

--- a/src/main/java/org/sonar/plugins/stash/client/StashCredentials.java
+++ b/src/main/java/org/sonar/plugins/stash/client/StashCredentials.java
@@ -4,10 +4,12 @@ public class StashCredentials {
 
   private final String login;
   private final String password;
+  private final String userSlug;
 
-  public StashCredentials(String login, String password) {
+  public StashCredentials(String login, String password, String userSlug) {
     this.login = login;
     this.password = password;
+    this.userSlug = userSlug;
   }
 
   public String getLogin() {
@@ -16,6 +18,10 @@ public class StashCredentials {
 
   public String getPassword() {
     return password;
+  }
+
+  public String getUserSlug() {
+    return userSlug;
   }
 
 }

--- a/src/test/java/org/sonar/plugins/stash/StashIssueReportingPostJobTest.java
+++ b/src/test/java/org/sonar/plugins/stash/StashIssueReportingPostJobTest.java
@@ -60,7 +60,8 @@ public class StashIssueReportingPostJobTest extends StashTest {
   private static final String STASH_PROJECT = "Project";
   private static final String STASH_REPOSITORY = "Repository";
   private static final int STASH_PULLREQUEST_ID = 1;
-  private static final String STASH_LOGIN = "login";
+  private static final String STASH_LOGIN = "login@email.com";
+  private static final String STASH_USER_SLUG = "login";
   private static final String STASH_PASSWORD = "password";
   private static final String STASH_URL = "http://url/to/stash";
   private static final int STASH_TIMEOUT = 10000;
@@ -96,7 +97,7 @@ public class StashIssueReportingPostJobTest extends StashTest {
     when(stashRequestFacade.getStashProject()).thenReturn(STASH_PROJECT);
     when(stashRequestFacade.getStashRepository()).thenReturn(STASH_REPOSITORY);
     when(stashRequestFacade.getStashPullRequestId()).thenReturn(STASH_PULLREQUEST_ID);
-    when(stashRequestFacade.getCredentials()).thenReturn(new StashCredentials(STASH_LOGIN, STASH_PASSWORD));
+    when(stashRequestFacade.getCredentials()).thenReturn(new StashCredentials(STASH_LOGIN, STASH_PASSWORD, STASH_USER_SLUG));
     when(stashRequestFacade.getSonarQubeReviewer(Mockito.anyString(), (StashClient) Mockito.anyObject())).thenReturn(stashUser);
     when(stashRequestFacade.getPullRequestDiffReport(eq(pr), (StashClient) Mockito.anyObject())).thenReturn(diffReport);
     when(stashRequestFacade.getIssueThreshold()).thenReturn(STASH_ISSUE_THRESHOLD);

--- a/src/test/java/org/sonar/plugins/stash/client/StashClientTest.java
+++ b/src/test/java/org/sonar/plugins/stash/client/StashClientTest.java
@@ -66,7 +66,7 @@ public class StashClientTest extends StashTest {
   public void setUp() throws Exception {
     primeWireMock();
     client = new StashClient("http://127.0.0.1:" + wireMock.port(),
-            new StashCredentials("login", "password"),
+            new StashCredentials("login@email.com", "password", "login"),
             timeout,
             "dummyVersion");
   }


### PR DESCRIPTION
When we upgraded to Stash 4.13.1, I noticed that the login and the user.slug value passed to the stash API were not the same.   This started causing failures when trying to report issues to stash via the plugin, because the user could no longer be found.

We needed to be able to set a user.slug to send to stash independently of sonar.stash.login.   I've added a configuration property that will allow this.  If no value for sonar.stash.user.slug is configured, it will default to using the login, which retains the original behaviour.