### PR TITLE
generate our own effective resource key

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/InputFileCacheSensor.java
+++ b/src/main/java/org/sonar/plugins/stash/InputFileCacheSensor.java
@@ -1,11 +1,14 @@
 package org.sonar.plugins.stash;
 
+import com.google.common.base.Optional;
+
 import org.sonar.api.BatchComponent;
 import org.sonar.api.batch.Sensor;
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.resources.Project;
+import org.sonar.api.resources.Resource;
 
 /*
  * FIXME this should not be necessary, the new plugin API gives us direct access to the InputFile of an issue
@@ -24,7 +27,7 @@ public class InputFileCacheSensor implements Sensor, BatchComponent {
     @Override
     public void analyse(Project module, SensorContext context) {
         for (InputFile inputFile : fileSystem.inputFiles(fileSystem.predicates().all())) {
-            inputFileCache.putInputFile(context.getResource(inputFile).getEffectiveKey(), inputFile);
+            inputFileCache.putInputFile(computeEffectiveKey(context.getResource(inputFile), module), inputFile);
         }
     }
 
@@ -36,5 +39,11 @@ public class InputFileCacheSensor implements Sensor, BatchComponent {
     @Override
     public String toString() {
         return "Stash Plugin Inputfile Cache";
+    }
+
+    public static String computeEffectiveKey(Resource resource, Project module) {
+        return Optional.fromNullable(
+                resource.getEffectiveKey()).or(() ->
+                module.getKey() + ":" + resource.getKey());
     }
 }


### PR DESCRIPTION
This is necessary as 6.3 does not provide it anymore