### PR TITLE
Use Proxy Selector

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/client/StashClient.java
+++ b/src/main/java/org/sonar/plugins/stash/client/StashClient.java
@@ -436,6 +436,7 @@ public class StashClient implements AutoCloseable {
         new DefaultAsyncHttpClientConfig.Builder()
             .setUserAgent(getUserAgent(sonarQubeVersion))
             .setCompressionEnforced(true)
+            .setUseProxySelector(true)
             .build()
     );
   }


### PR DESCRIPTION
If a proxy is configured for the process (e.g. http.proxyHost is defined) it will be used, otherwise it wont do anything. Fixes #143