### PR TITLE
Add new functionality to show filenames in the analysis overview

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/StashPlugin.java
+++ b/src/main/java/org/sonar/plugins/stash/StashPlugin.java
@@ -39,6 +39,7 @@ public class StashPlugin implements Plugin {
   private static final String DEFAULT_STASH_THRESHOLD_VALUE = "100";
   private static final boolean DEFAULT_STASH_ANALYSIS_OVERVIEW = true;
   private static final boolean DEFAULT_STASH_INCLUDE_EXISTING_ISSUES = false;
+  private static final int DEFAULT_STASH_FILES_IN_OVERVIEW = 0;
   private static final int DEFAULT_STASH_INCLUDE_VICINITY_RANGE = StashDiffReport.VICINITY_RANGE_NONE;
   private static final String DEFAULT_STASH_EXCLUDE_RULES = "";
 
@@ -76,6 +77,7 @@ public class StashPlugin implements Plugin {
   public static final String STASH_INCLUDE_ANALYSIS_OVERVIEW = "sonar.stash.include.overview";
   public static final String STASH_REPOSITORY_ROOT = "sonar.stash.repository.root";
   public static final String STASH_INCLUDE_EXISTING_ISSUES = "sonar.stash.include.existing.issues";
+  public static final String STASH_FILES_LIMIT_IN_OVERVIEW = "sonar.stash.overview.filenames";
   public static final String STASH_INCLUDE_VICINITY_RANGE = "sonar.stash.include.vicinity.issues.range";
   public static final String STASH_EXCLUDE_RULES = "sonar.stash.exclude.rules";
 
@@ -155,11 +157,20 @@ public class StashPlugin implements Plugin {
                           .options(SEVERITY_LIST_WITH_NONE).build(),
         PropertyDefinition.builder(STASH_INCLUDE_ANALYSIS_OVERVIEW)
                           .name("Include Analysis Overview Comment")
-                          .description("Create a comment to  the Pull Request providing a overview of the results")
+                          .description("Create a comment to the Pull Request providing a overview of the results")
                           .type(PropertyType.BOOLEAN)
                           .subCategory(CONFIG_PAGE_SUB_CATEGORY_STASH)
                           .onQualifiers(Qualifiers.PROJECT)
                           .defaultValue(Boolean.toString(DEFAULT_STASH_ANALYSIS_OVERVIEW)).build(),
+        PropertyDefinition.builder(STASH_FILES_LIMIT_IN_OVERVIEW)
+                          .name("Include Files in Overview")
+                          .description("Will extend the Analysis Overview comment to include the files where the " +
+                                  "issues where found. Set to any positive number to limit how many files per issue " +
+                                  "will be shown. Set to 0 to disable this feature.")
+                          .type(PropertyType.INTEGER)
+                          .subCategory(CONFIG_PAGE_SUB_CATEGORY_STASH)
+                          .onQualifiers(Qualifiers.PROJECT)
+                          .defaultValue(String.valueOf(DEFAULT_STASH_FILES_IN_OVERVIEW)).build(),
         PropertyDefinition.builder(STASH_INCLUDE_EXISTING_ISSUES)
                           .name("Include Existing Issues")
                           .description("Set to true to include already existing issues on modified lines.")

--- a/src/main/java/org/sonar/plugins/stash/StashPluginConfiguration.java
+++ b/src/main/java/org/sonar/plugins/stash/StashPluginConfiguration.java
@@ -114,6 +114,10 @@ public class StashPluginConfiguration {
     return settings.getBoolean(StashPlugin.STASH_INCLUDE_EXISTING_ISSUES);
   }
 
+  public int getFilesLimitInOverview() {
+    return settings.getInt(StashPlugin.STASH_FILES_LIMIT_IN_OVERVIEW);
+  }
+
   public int issueVicinityRange() {
     return settings.getInt(StashPlugin.STASH_INCLUDE_VICINITY_RANGE);
   }

--- a/src/main/java/org/sonar/plugins/stash/StashRequestFacade.java
+++ b/src/main/java/org/sonar/plugins/stash/StashRequestFacade.java
@@ -54,7 +54,7 @@ public class StashRequestFacade implements IssuePathResolver {
   }
 
   private MarkdownPrinter getMarkdownPrinter() throws StashConfigurationException {
-    return new MarkdownPrinter(getIssueThreshold(), config.getSonarQubeURL());
+    return new MarkdownPrinter(getIssueThreshold(), config.getSonarQubeURL(), config.getFilesLimitInOverview(), this);
   }
 
   /**

--- a/src/test/java/org/sonar/plugins/stash/StashRequestFacadeTest.java
+++ b/src/test/java/org/sonar/plugins/stash/StashRequestFacadeTest.java
@@ -150,7 +150,7 @@ public class StashRequestFacadeTest extends StashTest {
     stashUser = mock(StashUser.class);
     when(stashUser.getId()).thenReturn((long) 1234);
 
-    MarkdownPrinter printer = new MarkdownPrinter( 100, SONARQUBE_URL);
+    MarkdownPrinter printer = new MarkdownPrinter(100, SONARQUBE_URL, 0, new DummyIssuePathResolver());
 
     report = new ArrayList<PostJobIssue>();
 


### PR DESCRIPTION
This functionality is useful because inline comments are limited to where the diff only happened but we scan the whole file and in the overview we get the accumulated report of found issues but no way to see where these issues are exactly located. Also there is a config to disable/enable this feature.

Just a preview how it will look like:
![screen shot 2018-04-09 at 17 30 52](https://user-images.githubusercontent.com/2048953/38507061-c5682822-3c1b-11e8-8d02-c4fba22e29d5.png)

