### PR TITLE
[FIX] Added charset UTF-8 in requestBuilder

### DIFF
--- a/src/main/java/org/sonar/plugins/stash/client/StashClient.java
+++ b/src/main/java/org/sonar/plugins/stash/client/StashClient.java
@@ -1,5 +1,6 @@
 package org.sonar.plugins.stash.client;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
@@ -351,6 +352,7 @@ public class StashClient implements AutoCloseable {
     requestBuilder.setFollowRedirect(true);
     requestBuilder.addHeader("Content-Type", JSON.toString());
     requestBuilder.addHeader("Accept", JSON.toString());
+    requestBuilder.setCharset(StandardCharsets.UTF_8);
 
     Request request = requestBuilder.build();
     MDC.put(MDC_URL_KEY, request.getUrl());


### PR DESCRIPTION
We had an issue with sending a comment with special characters like the norwegian letter "ø" to stash. I added charset UTF-8 in requestBuilder. 
Insight from Wikipedia about Json:  JSON exchange in an open ecosystem must be encoded in UTF-8. (https://en.wikipedia.org/wiki/JSON)